### PR TITLE
hw4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,8 @@ OBJS = \
   $K/sysfile.o \
   $K/kernelvec.o \
   $K/plic.o \
-  $K/virtio_disk.o
+  $K/virtio_disk.o \
+  $K/pages.o 
 
 # riscv64-unknown-elf- or riscv64-linux-gnu-
 # perhaps in /opt/riscv/bin
@@ -141,6 +142,7 @@ UPROGS=\
 	$U/_zombie\
 	$U/_sum\
 	$U/_sum_asm\
+	$U/_pages_info\
 
 fs.img: mkfs/mkfs README $(UPROGS)
 	mkfs/mkfs fs.img README $(UPROGS)

--- a/kernel/pages.c
+++ b/kernel/pages.c
@@ -1,0 +1,132 @@
+#include "types.h"
+#include "riscv.h"
+#include "defs.h"
+#include "param.h"
+#include "memlayout.h"
+#include "spinlock.h"
+#include "proc.h"
+
+void print_pte(pagetable_t paget, int lvl, uint64 vab, int mask, uint64 buf_start, uint64 buf_end) {
+    uint64 mult = 4096;
+    if (lvl == 1)
+        mult *= 512;
+    if (lvl == 2) 
+        mult *= 512 * 512;
+    for (int i = 0; i < 512; ++i) {
+        pte_t pte = paget[i];
+        if (!(pte & PTE_V)) 
+            continue;
+
+        uint64 va = vab | ((uint64)i << PXSHIFT(lvl));
+        if (va >= buf_end || (va + mult) <= buf_start)
+            continue;
+        int ni = 2, na = 15;
+        uint64 di = 16;
+        while (i / di != 0) {
+            ni--;
+            di *= 16;
+        }
+        di = 10;
+        while (PTE2PA(pte) / di != 0) {
+            na--;
+            di *= 16;
+        }
+
+        char flags[8] = "_______\0";
+        char flagsLits[8] = "RWXUGAD\0";
+        uint64 pte_flags = PTE_FLAGS(pte);
+        for (int j = 1; j < 8; ++j) {
+            if (pte_flags & (1L << j)) 
+                flags[j - 1] = flagsLits[j - 1];
+        }
+        
+        if (lvl == 0 && (mask & 1) && (flags[6] != 'D'))
+            continue;
+        if (lvl == 0 && (mask & 2) && (flags[5] != 'A'))
+            continue;
+
+        for (int j = 0; j < 9 * (2 - lvl); ++j)
+            printf(".");
+        printf("0x");
+        for (int j = 0; j < ni; ++j) printf("0");
+        printf("%x -> ", i);
+        printf("0x");
+        for (int j = 0; j < na; ++j) printf("0");
+        printf("%lx ", PTE2PA(pte));
+        printf("%s\n", flags);
+
+        if (lvl != 0) 
+            print_pte((pagetable_t)PTE2PA(pte), lvl - 1, va, mask, buf_start, buf_end);
+    }
+}
+
+void strip_flags(pagetable_t paget, int lvl, uint64 vab, int mask, uint64 buf_start, uint64 buf_end) {
+    uint64 mult = 4096;
+    if (lvl == 1)
+        mult *= 512;
+    if (lvl == 2) 
+        mult *= 512 * 512;
+    for (int i = 0; i < 512; ++i) {
+        pte_t pte = paget[i];
+        if (!(pte & PTE_V)) 
+            continue;
+
+        uint64 va = vab | ((uint64)i << PXSHIFT(lvl));
+        if (va >= buf_end || (va + mult) <= buf_start)
+            continue;
+
+        if (lvl == 0 && (mask & 1) && (pte & (1L << 7))) 
+            paget[i] &= ~(1L << 7);
+        if (lvl == 0 && (mask & 2) && (pte & (1L << 6))) 
+            paget[i] &= ~(1L << 6);
+
+        if (lvl != 0) 
+            strip_flags((pagetable_t)PTE2PA(pte), lvl - 1, va, mask, buf_start, buf_end);
+    }
+}
+
+
+uint64
+sys_pages(void)
+{
+  uint64 buf, len;
+  int mask;
+
+  argaddr(0, &buf);
+  argaddr(1, &len);
+  argint(2, &mask);
+  if (mask > 3 || mask < 0)
+    return -1;
+  
+  if (buf == 0 || len == 0) {
+    buf = 0;
+    len = MAXVA - 1;
+  }
+
+  pte_t *pte = myproc()->pagetable;
+  printf("PAGETABLE %p\n", pte);
+  print_pte(pte, 2, 0, mask, buf, buf + len);
+  return 0;
+}
+
+uint64
+sys_strip_flags(void)
+{
+    uint64 buf, len;
+    int mask;
+  
+    argaddr(0, &buf);
+    argaddr(1, &len);
+    argint(2, &mask);
+    if (mask > 3 || mask < 0)
+      return -1;
+    
+    if (buf == 0 || len == 0) {
+      buf = 0;
+      len = MAXVA - 1;
+    }
+
+    pte_t *pte = myproc()->pagetable;
+    strip_flags(pte, 2, 0, mask, buf, buf + len);
+    return 0;
+}

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -102,6 +102,8 @@ extern uint64 sys_link(void);
 extern uint64 sys_mkdir(void);
 extern uint64 sys_close(void);
 extern uint64 sys_add(void);
+extern uint64 sys_pages(void);
+extern uint64 sys_strip_flags(void);
 
 // An array mapping syscall numbers from syscall.h
 // to the function that handles the system call.
@@ -128,6 +130,8 @@ static uint64 (*syscalls[])(void) = {
 [SYS_mkdir]   sys_mkdir,
 [SYS_close]   sys_close,
 [SYS_add]     sys_add,
+[SYS_pages]   sys_pages,
+[SYS_strip_flags] sys_strip_flags,
 };
 
 void

--- a/kernel/syscall.h
+++ b/kernel/syscall.h
@@ -21,3 +21,5 @@
 #define SYS_mkdir  20
 #define SYS_close  21
 #define SYS_add    22
+#define SYS_pages  23
+#define SYS_strip_flags 24

--- a/user/pages_info.c
+++ b/user/pages_info.c
@@ -1,0 +1,51 @@
+#include "kernel/types.h"
+#include "kernel/stat.h"
+#include "user/user.h"
+
+int global_var = 100;  
+
+int main(int argc, char **argv) {
+    int stack_var = 200; 
+
+    printf("---- Таблица страниц при старте ----\n\n");
+    pages(0, 0, 0);
+
+    int size = 3 * 4096;  
+    char *heap_array = sbrk(size);
+    if ((uint64)heap_array == -1) {
+        printf("sbrk failed\n");
+        exit(1);
+    }
+
+    memset(heap_array, 0, size); 
+    printf("\n---- После выделения кучи (%d байт) ----\n\n", size);
+    pages(0, 0, 0);
+
+    printf("\n---- Страницы, содержащие часть кучи (ее 4096 байт с отступом на 10)) ----\n\n");
+    pages((uint64 *)(heap_array + 10), 4096, 0);
+
+    printf("\n---- После снятия A и D куску кучи выше ----\n\n");
+    strip_flags((uint64 *)(heap_array + 10), 4096, 3);
+    pages(0, 0, 0);
+
+    printf("\n---- После снятия A и D всем ----\n\n");
+    strip_flags(0, 0, 3);
+    pages(0, 0, 0);
+
+    int temp = global_var + stack_var + heap_array[0];
+    printf("%d\n", temp); // to prevent unused var varning
+    printf("\n---- После чтения данных (ожидается установка бита A) ----\n\n");
+    pages(0, 0, 2); 
+
+    global_var += 1;
+    stack_var += 1;
+    heap_array[0] += 1;
+    printf("\n---- После изменения данных (ожидается установка бита D) ----\n\n");
+    pages(0, 0, 1);  
+
+    sbrk(-size);
+    printf("\n---- После освобождения кучи ----\n\n");
+    pages(0, 0, 0);
+
+    exit(0);
+}

--- a/user/user.h
+++ b/user/user.h
@@ -23,6 +23,8 @@ char* sbrk(int);
 int sleep(int);
 int uptime(void);
 int add(int x, int y);
+int pages(void *buf, int len, int mask);
+int strip_flags(void *buf, int len, int mask);
 
 // ulib.c
 int stat(const char*, struct stat*);

--- a/user/usys.pl
+++ b/user/usys.pl
@@ -36,4 +36,6 @@ entry("getpid");
 entry("sbrk");
 entry("sleep");
 entry("uptime");
-entry("add")
+entry("add");
+entry("pages");
+entry("strip_flags")


### PR DESCRIPTION
Создать системный вызов для вывода используемых процессом страниц памяти

Параметры системного вызова: указатель на буфер, длина буфера, выводимые страницы

Если указатель или длина = 0, производить действие над всеми страницами процесса.

Если указатель или длина не нулевые и задают буфер, принадлежащий адресному пространству процесса, обработать только те страницы, в которых находится буфер (см. реализацию copyin/copyout).

Выводимые страницы: если задано 0 - вывод всей таблицы страниц, ненулевое значение - битовая маска вывода измененных страниц (флаг D) и вывод страниц, к которым было обращение (флаг A). При некорректном значении возвращать ошибку.

Вывод должен быть в следующем формате (прямо из ядра на консоль):


PAGETABLE 0x012345678ABCD000
0x001 -> 0x012345678ABCD000 RWXUGAD
......... 0x001 -> 0x012345678ABCD000 RWXUGAD
...................0x001 -> 0x012345678ABCD000 RWXUGAD
...................0x002 -> 0x012345678ABCD000 RWXUGAD

...................0x003 -> 0x012345678ABCD000 RWXUGAD
                   <...>
......... 0x002 -> 0x012345678ABCD000 RWXUGAD
                   <...>
0x002 -> 0x012345678ABCD000 RWXUGAD
                   <...>
Где

0x012345678ABCD000 - физические адреса соответствующей страницы - PTE2PA
0x123 - индекс в таблице страниц

RWXUGAD - установленные флаги (вместо буквы писать _, если флаг не установлен) - PTE_* (добавить недостающие)

Создать системный вызов, снимающий флаги D и A у страниц

Параметры системного вызова: указатель на буфер, длина буфера (с аналогичным смыслом), какие флаги снимать - битовая маска снятия флага D и снятие флага A (при некорректном значении возвращать ошибку).

В обоих вызовах выводить и обрабатывать только действительные страницы процесса (флаг V), обратить внимание на функцию walk и макросы PTE_, и только запрошенные страницы (если задан буфер/флаги).*

Протестировать работу с помощью программы пользовательского пространства на глобальных и стековых одиночных переменных, и элементах массивов, расположенных в стеке и в куче. Массив в куче должен занимать несколько страниц. Показать таблицу страниц при старте, после выделения памяти, после снятия A и D у всех страниц, появление атрибутов после чтения данных, после изменения данных, после освобождения памяти (при выделении и освобождении памяти выводить всю таблицу, при тесте доступа и изменения - только измененные страницы: свести вывод к необходимому минимуму для иллюстрации эффектов и работы).