### PR TITLE
hw6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,8 @@ OBJS = \
   $K/sysfile.o \
   $K/kernelvec.o \
   $K/plic.o \
-  $K/virtio_disk.o
+  $K/virtio_disk.o \
+  $K/devps.o
 
 # riscv64-unknown-elf- or riscv64-linux-gnu-
 # perhaps in /opt/riscv/bin
@@ -141,6 +142,8 @@ UPROGS=\
 	$U/_zombie\
 	$U/_sum\
 	$U/_sum_asm\
+	$U/_hexdump\
+	$U/_devtest\
 
 fs.img: mkfs/mkfs README $(UPROGS)
 	mkfs/mkfs fs.img README $(UPROGS)

--- a/kernel/console.c
+++ b/kernel/console.c
@@ -56,7 +56,7 @@ struct {
 // user write()s to the console go here.
 //
 int
-consolewrite(int user_src, uint64 src, int n)
+consolewrite(int user_src, uint64 src, int n, short minor)
 {
   int i;
 
@@ -77,7 +77,7 @@ consolewrite(int user_src, uint64 src, int n)
 // or kernel address.
 //
 int
-consoleread(int user_dst, uint64 dst, int n)
+consoleread(int user_dst, uint64 dst, int n, short minor)
 {
   uint target;
   int c;

--- a/kernel/devps.c
+++ b/kernel/devps.c
@@ -12,6 +12,9 @@
 #define URANDOM 2
 #define NULLSTAT 3
 
+#define BUF_SIZE 512
+char null_buf[BUF_SIZE];
+
 struct pseudo {
   struct spinlock lock;
   uint64 seed;
@@ -29,29 +32,35 @@ int
 ps_read(int user_dst, uint64 dst, int n, short minor) 
 {
   int r = -1;
-  acquire(&devps.lock);
   switch (minor) {
     case NULL:
       r = 0;
       break;
     case ZERO:
-      for (int i = 0; i < n; i++) {
-        uint8 zero = 0;
-        if (either_copyout(user_dst, dst + i, &zero, 1) < 0) {
+      int cpy_n = n;
+      uint64 cur_dst = dst;
+      while (cpy_n > 0) {
+        int chunk = cpy_n < BUF_SIZE ? cpy_n : BUF_SIZE;
+        if (either_copyout(user_dst, cur_dst, null_buf, chunk) < 0) {
           r = -1;
           break;
         }
+        cur_dst += chunk;
+        cpy_n -= chunk;
       }
       r = n;
       break;
     case URANDOM:
+      acquire(&devps.lock);
       for (int i = 0; i < n; i++) {
         uint8 new = urandom_next();
         if (either_copyout(user_dst, dst + i, &new, 1) < 0) {
           r = -1;
+          release(&devps.lock);
           break;
         }
       }
+      release(&devps.lock);
       r = n;
       break;
     case NULLSTAT:
@@ -59,16 +68,18 @@ ps_read(int user_dst, uint64 dst, int n, short minor)
         r = -1;
         break;
       }
+      acquire(&devps.lock);
       if (either_copyout(user_dst, dst, &devps.cnt, n) < 0) {
         r = -1;
+        release(&devps.lock);
         break;
       }
+      release(&devps.lock);
       r = n;
       break;
     default:
       break;
   }
-  release(&devps.lock);
   
   return r;
 }
@@ -77,7 +88,6 @@ int
 ps_write(int user_src, uint64 src, int n, short minor)
 {
   int r = -1;
-  acquire(&devps.lock);
   switch (minor) {
     case NULL:
       r = n;
@@ -95,17 +105,20 @@ ps_write(int user_src, uint64 src, int n, short minor)
         r = -1;
         break;
       }
+      acquire(&devps.lock);
       devps.seed = nseed;
+      release(&devps.lock);
         r = n;
         break;
     case NULLSTAT:
+      acquire(&devps.lock);
       devps.cnt += n;
+      release(&devps.lock);
       r = n;
       break;
     default:
       break;
   }
-  release(&devps.lock);
 
   return r;
 }
@@ -114,6 +127,8 @@ void
 devps_init(void) 
 {
     initlock(&devps.lock, "dev");
+    for (int i = 0; i < BUF_SIZE; ++i)
+      null_buf[i] = 0;
     devps.seed = 1337; devps.cnt = 0;
     devsw[PS_DEV].read = ps_read;
     devsw[PS_DEV].write = ps_write;

--- a/kernel/devps.c
+++ b/kernel/devps.c
@@ -1,0 +1,120 @@
+#include "types.h"
+#include "riscv.h"
+#include "param.h"
+#include "spinlock.h"
+#include "sleeplock.h"
+#include "fs.h"
+#include "defs.h"
+#include "file.h"
+
+#define NULL 0
+#define ZERO 1
+#define URANDOM 2
+#define NULLSTAT 3
+
+struct pseudo {
+  struct spinlock lock;
+  uint64 seed;
+  uint64 cnt;
+};
+
+static struct pseudo devps;
+
+uint8 urandom_next() {
+  devps.seed = devps.seed * 6364136223846793005ull + 1;
+  return (uint8)(devps.seed >> 56);
+}
+
+int 
+ps_read(int user_dst, uint64 dst, int n, short minor) 
+{
+  int r = -1;
+  acquire(&devps.lock);
+  switch (minor) {
+    case NULL:
+      r = 0;
+      break;
+    case ZERO:
+      for (int i = 0; i < n; i++) {
+        uint8 zero = 0;
+        if (either_copyout(user_dst, dst + i, &zero, 1) < 0) {
+          r = -1;
+          break;
+        }
+      }
+      r = n;
+      break;
+    case URANDOM:
+      for (int i = 0; i < n; i++) {
+        uint8 new = urandom_next();
+        if (either_copyout(user_dst, dst + i, &new, 1) < 0) {
+          r = -1;
+          break;
+        }
+      }
+      r = n;
+      break;
+    case NULLSTAT:
+      if (n != sizeof(uint64)) {
+        r = -1;
+        break;
+      }
+      if (either_copyout(user_dst, dst, &devps.cnt, n) < 0) {
+        r = -1;
+        break;
+      }
+      r = n;
+      break;
+    default:
+      break;
+  }
+  release(&devps.lock);
+  
+  return r;
+}
+
+int 
+ps_write(int user_src, uint64 src, int n, short minor)
+{
+  int r = -1;
+  acquire(&devps.lock);
+  switch (minor) {
+    case NULL:
+      r = n;
+      break;
+    case ZERO:
+      r = -1;
+      break;
+    case URANDOM:
+      if (n != sizeof(uint64)) {
+        r = -1;
+        break;
+      }
+      uint64 nseed;
+      if (either_copyin(&nseed, user_src, src, n) < 0) {
+        r = -1;
+        break;
+      }
+      devps.seed = nseed;
+        r = n;
+        break;
+    case NULLSTAT:
+      devps.cnt += n;
+      r = n;
+      break;
+    default:
+      break;
+  }
+  release(&devps.lock);
+
+  return r;
+}
+
+void 
+devps_init(void) 
+{
+    initlock(&devps.lock, "dev");
+    devps.seed = 1337; devps.cnt = 0;
+    devsw[PS_DEV].read = ps_read;
+    devsw[PS_DEV].write = ps_write;
+}

--- a/kernel/file.c
+++ b/kernel/file.c
@@ -116,7 +116,7 @@ fileread(struct file *f, uint64 addr, int n)
   } else if(f->type == FD_DEVICE){
     if(f->major < 0 || f->major >= NDEV || !devsw[f->major].read)
       return -1;
-    r = devsw[f->major].read(1, addr, n);
+    r = devsw[f->major].read(1, addr, n, f->minor);
   } else if(f->type == FD_INODE){
     ilock(f->ip);
     if((r = readi(f->ip, 1, addr, f->off, n)) > 0)
@@ -144,7 +144,7 @@ filewrite(struct file *f, uint64 addr, int n)
   } else if(f->type == FD_DEVICE){
     if(f->major < 0 || f->major >= NDEV || !devsw[f->major].write)
       return -1;
-    ret = devsw[f->major].write(1, addr, n);
+    ret = devsw[f->major].write(1, addr, n, f->minor);
   } else if(f->type == FD_INODE){
     // write a few blocks at a time to avoid exceeding
     // the maximum log transaction size, including

--- a/kernel/file.h
+++ b/kernel/file.h
@@ -7,6 +7,7 @@ struct file {
   struct inode *ip;  // FD_INODE and FD_DEVICE
   uint off;          // FD_INODE
   short major;       // FD_DEVICE
+  short minor;
 };
 
 #define major(dev)  ((dev) >> 16 & 0xFFFF)
@@ -31,10 +32,11 @@ struct inode {
 
 // map major device number to device functions.
 struct devsw {
-  int (*read)(int, uint64, int);
-  int (*write)(int, uint64, int);
+  int (*read)(int, uint64, int, short);
+  int (*write)(int, uint64, int, short);
 };
 
 extern struct devsw devsw[];
 
 #define CONSOLE 1
+#define PS_DEV 7

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -6,6 +6,8 @@
 
 volatile static int started = 0;
 
+extern void devps_init(void);
+
 // start() jumps here in supervisor mode on all CPUs.
 void
 main()
@@ -29,6 +31,7 @@ main()
     fileinit();      // file table
     virtio_disk_init(); // emulated hard disk
     userinit();      // first user process
+    devps_init();
     __sync_synchronize();
     started = 1;
   } else {

--- a/kernel/sysfile.c
+++ b/kernel/sysfile.c
@@ -352,6 +352,7 @@ sys_open(void)
   if(ip->type == T_DEVICE){
     f->type = FD_DEVICE;
     f->major = ip->major;
+    f->minor = ip->minor;
   } else {
     f->type = FD_INODE;
     f->off = 0;

--- a/user/devtest.c
+++ b/user/devtest.c
@@ -1,0 +1,75 @@
+#include "kernel/types.h"
+#include "kernel/stat.h"
+#include "kernel/fcntl.h"
+#include "user/user.h"
+
+int
+main(int argc, char *argv[])
+{
+  int fd, ret;
+
+  printf("\n---- Testing /dev/null ----\n");
+  fd = open("/dev/null", O_RDWR);
+  if (fd < 0) { 
+    printf("cannot open /dev/null\n"); 
+    exit(1); 
+  }
+  ret = write(fd, "xyz", 3);
+  printf("write to null: %d bytes\n", ret);
+  ret = read(fd, argv, 1);
+  printf("read from null: %d bytes (should be 0)\n", ret);
+  close(fd);
+
+  printf("\n---- Testing /dev/zero with direct read ----\n");
+  fd = open("/dev/zero", O_RDONLY);
+  if (fd < 0) { 
+    printf("cannot open /dev/zero\n"); 
+    exit(1); 
+  }
+  char buf[4];
+  ret = read(fd, buf, sizeof(buf));
+  printf("zero bytes: %d %d %d %d\n", buf[0], buf[1], buf[2], buf[3]);
+  close(fd);
+
+  printf("\n---- Hexdump 4 bytes from /dev/zero ----\n");
+  if (fork() == 0) {
+    char *args[] = { "hexdump", "/dev/zero", "4", 0 };
+    exec("hexdump", args);
+    printf("exec hexdump failed\n");
+    exit(1);
+  }
+  wait(0);
+
+  printf("\n---- Testing /dev/urandom ----\n");
+  fd = open("/dev/urandom", O_RDONLY);
+  if (fd < 0) { 
+    printf("cannot open /dev/urandom\n"); 
+    exit(1); 
+  }
+  ret = read(fd, buf, 3);
+  printf("random bytes: %d %d %d (read %d)\n", buf[0], buf[1], buf[2], ret);
+  close(fd);
+
+  printf("\n---- Testing /dev/nullstat via both methods ----\n");
+  fd = open("/dev/nullstat", O_RDWR);
+  if (fd < 0) { 
+    printf("cannot open /dev/nullstat\n"); 
+    exit(1); 
+  }
+  write(fd, "1234567", 7);
+  write(fd, "6789", 4);
+  uint64 cnt;
+  ret = read(fd, &cnt, sizeof(cnt));
+  printf("nullstat count via C: %d\n", (int)cnt);
+  close(fd);
+
+  printf("\n---- Hexdump 8 bytes from /dev/nullstat ----\n");
+  if (fork() == 0) {
+    char *args2[] = { "hexdump", "/dev/nullstat", "8", 0 };
+    exec("hexdump", args2);
+    exit(1);
+  }
+  wait(0);
+
+  exit(0);
+}

--- a/user/hexdump.c
+++ b/user/hexdump.c
@@ -1,0 +1,55 @@
+#include "kernel/types.h"
+#include "kernel/stat.h"
+#include "kernel/fcntl.h"
+#include "user/user.h"
+
+#define BUF_SIZE 512
+
+static void
+print_byte(unsigned char b) {
+  static char *hex = "0123456789abcdef";
+  write(1, &hex[b >> 4], 1);
+  write(1, &hex[b & 0x0F], 1);
+}
+
+int
+main(int argc, char *argv[])
+{
+  if (argc != 3) {
+    printf("Usage: hexdump <file> <count>\n");
+    exit(1);
+  }
+
+  char *path = argv[1];
+  int to_print = atoi(argv[2]);
+  int fd = open(path, O_RDONLY);
+  if (fd < 0) {
+    printf("hexdump: cannot open %s\n", path);
+    exit(1);
+  }
+
+  unsigned char buf[BUF_SIZE];
+  int printed = 0;
+  int global_idx = 0;
+  while (printed < to_print) {
+    int chunk = to_print - printed;
+    if (chunk > BUF_SIZE) 
+      chunk = BUF_SIZE;
+    int n = read(fd, buf, chunk);
+    if (n <= 0)
+      break;
+    for (int i = 0; i < n; i++) {
+      print_byte(buf[i]);
+      write(1, " ", 1);
+      if ((global_idx & 0xF) == 0xF)
+        write(1, "\n", 1);
+      global_idx++;
+    }
+    printed += n;
+  }
+  if ((global_idx & 0xF) != 0)
+    write(1, "\n", 1);
+
+  close(fd);
+  exit(0);
+}

--- a/user/init.c
+++ b/user/init.c
@@ -23,6 +23,12 @@ main(void)
   dup(0);  // stdout
   dup(0);  // stderr
 
+  mkdir("/dev");
+  mknod("/dev/null", PS_DEV, 0);
+  mknod("/dev/zero", PS_DEV, 1);
+  mknod("/dev/urandom", PS_DEV, 2);
+  mknod("/dev/nullstat", PS_DEV, 3);
+
   for(;;){
     printf("init: starting sh\n");
     pid = fork();


### PR DESCRIPTION
Добавить в xv6 использования младших (minor) номеров устройств ввода/вывода — передачу их в функции чтения и записи с соответствующей модификацией всех связанных структур и функций ядра.

Реализовать драйвер, обеспечивающий поддержку ядром xv6 следующих псевдоустройств (один драйвер, разные младшие номера):

null — при чтении всегда возвращает «конец файла», все записываемые данные игнорируются (успех);

zero — при чтении возвращает нулевые байты, запись не допускается (возвращается ошибка);

urandom — при чтении возвращает равномерно распределенные случайные байты (можно реализовать датчик случайных чисел по линейному конгруэнтному методу), при записи меняет номер (seed) случайной последовательности (если длина записи соответствует длине переменной seed, иначе -— ошибка);

nullstat — при записи отбрасывает записываемые байты, но считает их количество (uint64), при чтении ровно sizeof(uint64) байтов возвращает общее количество записанных байт за все время работы (при несоответствии объема — ошибка чтения)

Обеспечить создание файлов всех указанных устройств при запуске системы (при старте init посредством mknod).

Протестировать работоспособность устройств, в т. ч. с использованием команды echo и утилиты cat и собственной утилиты, прочитывающей заданное количество байтов из заданного файла и выводящей их (лучше побайтовый hexdump).