### PR TITLE
hw7

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,8 @@ OBJS = \
   $K/sysfile.o \
   $K/kernelvec.o \
   $K/plic.o \
-  $K/virtio_disk.o
+  $K/virtio_disk.o \
+  $K/rtc.o \
 
 # riscv64-unknown-elf- or riscv64-linux-gnu-
 # perhaps in /opt/riscv/bin
@@ -141,6 +142,7 @@ UPROGS=\
 	$U/_zombie\
 	$U/_sum\
 	$U/_sum_asm\
+	$U/_data\
 
 fs.img: mkfs/mkfs README $(UPROGS)
 	mkfs/mkfs fs.img README $(UPROGS)
@@ -169,6 +171,7 @@ QEMUOPTS = -machine virt -bios none -kernel $K/kernel -m 128M -smp $(CPUS) -nogr
 QEMUOPTS += -global virtio-mmio.force-legacy=false
 QEMUOPTS += -drive file=fs.img,if=none,format=raw,id=x0
 QEMUOPTS += -device virtio-blk-device,drive=x0,bus=virtio-mmio-bus.0
+QEMUOPTS += -rtc base=localtime
 
 qemu: $K/kernel fs.img
 	$(QEMU) $(QEMUOPTS)

--- a/Makefile
+++ b/Makefile
@@ -171,7 +171,11 @@ QEMUOPTS = -machine virt -bios none -kernel $K/kernel -m 128M -smp $(CPUS) -nogr
 QEMUOPTS += -global virtio-mmio.force-legacy=false
 QEMUOPTS += -drive file=fs.img,if=none,format=raw,id=x0
 QEMUOPTS += -device virtio-blk-device,drive=x0,bus=virtio-mmio-bus.0
-QEMUOPTS += -rtc base=localtime
+ifdef RTC_BASE
+	QEMUOPTS += -rtc base=$(RTC_BASE)
+else
+	QEMUOPTS += -rtc base=localtime
+endif
 
 qemu: $K/kernel fs.img
 	$(QEMU) $(QEMUOPTS)

--- a/kernel/defs.h
+++ b/kernel/defs.h
@@ -185,5 +185,10 @@ void            virtio_disk_init(void);
 void            virtio_disk_rw(struct buf *, int);
 void            virtio_disk_intr(void);
 
+// rtc.c
+uint32          rtc_low(void);
+uint32          rtc_high(void);
+uint64          rtc_read(void);
+
 // number of elements in fixed-size array
 #define NELEM(x) (sizeof(x)/sizeof((x)[0]))

--- a/kernel/defs.h
+++ b/kernel/defs.h
@@ -186,6 +186,7 @@ void            virtio_disk_rw(struct buf *, int);
 void            virtio_disk_intr(void);
 
 // rtc.c
+void            rtcinit(void);
 uint32          rtc_low(void);
 uint32          rtc_high(void);
 uint64          rtc_read(void);

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -29,6 +29,7 @@ main()
     fileinit();      // file table
     virtio_disk_init(); // emulated hard disk
     userinit();      // first user process
+    rtcinit();
     __sync_synchronize();
     started = 1;
   } else {

--- a/kernel/memlayout.h
+++ b/kernel/memlayout.h
@@ -57,3 +57,8 @@
 //   TRAPFRAME (p->trapframe, used by the trampoline)
 //   TRAMPOLINE (the same page as in the kernel)
 #define TRAPFRAME (TRAMPOLINE - PGSIZE)
+
+
+#define RTC_ADDR 0x101000
+#define RTC_LOW RTC_ADDR
+#define RTC_HIGH (RTC_ADDR + 0x4)

--- a/kernel/rtc.c
+++ b/kernel/rtc.c
@@ -1,0 +1,25 @@
+#include "types.h"
+#include "memlayout.h"
+#include "riscv.h"
+
+#define RTC_REG(addr) (*(volatile uint32 *)(addr))
+
+uint32
+rtc_low(void)
+{
+    return RTC_REG(RTC_LOW);
+}
+
+uint32
+rtc_high(void)
+{
+    return RTC_REG(RTC_HIGH);
+}
+
+uint64
+rtc_read(void)
+{
+    uint32 low = rtc_low();
+    uint32 high = rtc_high();
+    return ((uint64)high << 32) + low;
+}

--- a/kernel/rtc.c
+++ b/kernel/rtc.c
@@ -1,8 +1,22 @@
 #include "types.h"
 #include "memlayout.h"
 #include "riscv.h"
+#include "param.h"
+#include "spinlock.h"
+#include "sleeplock.h"
+#include "fs.h"
+#include "defs.h"
+#include "file.h"
 
 #define RTC_REG(addr) (*(volatile uint32 *)(addr))
+
+static struct spinlock rtc_lock;
+
+void
+rtcinit(void) 
+{
+  initlock(&rtc_lock, "rtc");
+}
 
 uint32
 rtc_low(void)
@@ -19,7 +33,9 @@ rtc_high(void)
 uint64
 rtc_read(void)
 {
+    acquire(&rtc_lock);
     uint32 low = rtc_low();
     uint32 high = rtc_high();
+    release(&rtc_lock);
     return ((uint64)high << 32) + low;
 }

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -102,6 +102,7 @@ extern uint64 sys_link(void);
 extern uint64 sys_mkdir(void);
 extern uint64 sys_close(void);
 extern uint64 sys_add(void);
+extern uint64 sys_rtc(void);
 
 // An array mapping syscall numbers from syscall.h
 // to the function that handles the system call.
@@ -128,6 +129,7 @@ static uint64 (*syscalls[])(void) = {
 [SYS_mkdir]   sys_mkdir,
 [SYS_close]   sys_close,
 [SYS_add]     sys_add,
+[SYS_rtc]     sys_rtc,
 };
 
 void

--- a/kernel/syscall.h
+++ b/kernel/syscall.h
@@ -21,3 +21,4 @@
 #define SYS_mkdir  20
 #define SYS_close  21
 #define SYS_add    22
+#define SYS_rtc    23

--- a/kernel/sysproc.c
+++ b/kernel/sysproc.c
@@ -100,3 +100,8 @@ sys_add(void)
   argint(1, &y);
   return x + y;
 }
+
+uint64
+sys_rtc(void) {
+  return rtc_read();
+}

--- a/kernel/vm.c
+++ b/kernel/vm.c
@@ -43,6 +43,8 @@ kvmmake(void)
   // the highest virtual address in the kernel.
   kvmmap(kpgtbl, TRAMPOLINE, (uint64)trampoline, PGSIZE, PTE_R | PTE_X);
 
+  kvmmap(kpgtbl, RTC_ADDR, RTC_ADDR, PGSIZE, PTE_R);
+
   // allocate and map a kernel stack for each process.
   proc_mapstacks(kpgtbl);
   

--- a/user/data.c
+++ b/user/data.c
@@ -1,0 +1,65 @@
+#include "kernel/types.h"
+#include "kernel/stat.h"
+#include "user/user.h"
+
+#define START_POINT 1970
+
+#define DAY_YR 365
+#define HR_DAY 24
+#define MIN_HR 60
+#define SEC_MIN 60
+#define NS_MS 1000000
+#define NS_SEC 1000000000
+
+int days_mth[] = { 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31, };
+
+int leap_year(int year) {
+    if (year % 400 == 0) 
+        return 1;
+    if (year % 100 == 0) 
+        return 0;
+    if (year % 4 == 0) 
+        return 1;
+    return 0;
+}
+
+int main(int argc, char *argv[]) {
+    uint64 time = rtc();
+    uint32 nsecs = time % NS_SEC;
+    uint32 msecs = nsecs / NS_MS;
+    uint64 secs = time / NS_SEC % SEC_MIN;
+    uint32 mins = time / SEC_MIN / NS_SEC % MIN_HR;
+    uint32 hrs = time / MIN_HR / SEC_MIN / NS_SEC % HR_DAY;
+    uint32 days = time / HR_DAY / MIN_HR / SEC_MIN / NS_SEC;
+    uint32 yr = START_POINT;
+    uint32 mth = 0;
+
+    while (days >= DAY_YR + leap_year(yr)) {
+        ++yr;
+        days -= DAY_YR + leap_year(yr);
+    }
+    uint32 feb29 = 0;
+    while (1) {
+        if (mth == 1 && leap_year(yr) == 1) 
+            feb29 = 1;
+        if (days >= days_mth[mth] + feb29){
+            days -= days_mth[mth] + feb29;
+            mth++;
+        }
+        else break;
+        feb29 = 0;
+    }
+
+    printf("Date: %d.%d.%d\n", days + 1, mth + 1, yr);
+    printf("Time: %d:%d:%ld.", hrs, mins, secs);
+
+    char msecs_str[4];
+    msecs_str[3] = '\0';
+    int i = 2;
+    while (i >= 0) {
+        msecs_str[i] = '0' + msecs % 10;
+        msecs /= 10;
+        i--;
+    }
+    printf("%s\n", msecs_str);
+}

--- a/user/user.h
+++ b/user/user.h
@@ -23,6 +23,7 @@ char* sbrk(int);
 int sleep(int);
 int uptime(void);
 int add(int x, int y);
+long int rtc(void);
 
 // ulib.c
 int stat(const char*, struct stat*);

--- a/user/usys.pl
+++ b/user/usys.pl
@@ -36,4 +36,5 @@ entry("getpid");
 entry("sbrk");
 entry("sleep");
 entry("uptime");
-entry("add")
+entry("add");
+entry("rtc");


### PR DESCRIPTION
Реализовать поддержку часов реального времени в xv6. В виртуальной машине QEMU реализована поддержка виртуальных часов реального времени Goldfish RTC. Показания часов могут быть считаны с помощью отображения регистров устройства в память. Физический адрес регистров устройства начинается с позиции 0x101000. Сами показания часов представляют собой 64-разрядное значение, выражающее количество наносекунд, прошедшее с полуночи 1 января 1970 года. Они записаны в двух регистрах устройства RTC, содержащих, соответственно младшее (LOW) слово и старшее (HIGH) слово (32 бита) значения. Регистр со значением младшего слова расположен непосредственно по адресу 0x101000, старшего — со смещением в 4 байта.

За один акт обращения к памяти нужно считывать строго одно значение регистра, при этом сначала считать младшее, а затем старшее слово. Для реализации средств чтения значения RTC следует:

зарегистрировать константы для позиций регистра младшего и старшего слова значения таймера в файле memlayout.h;

обеспечить отображение регистров RTC в адресное пространство ядра, например, вызвав функцию kvmmap в функции реализации адресного пространства ядра kvmmake (файл vm.c) — по аналогии с тем, как отображаются регистры консоли UART;

создать в ядре функции чтения регистров младшего и старшего слова значения таймера, например, по аналогии с макросами ReadReg и Reg для консоли UART (файл uart.c): важно обратить внимание на используемый тип данных (uint32) и указание ключевого слова volatile

создать в ядре функцию, прочитывающую регистры значения таймера в нужном порядке и формирующую из них корректное 64-разрядное значение времени, а также системный вызов, передающий его в пользовательское пространство;

добавить в опции запуска QEMU в Makefile ключ -rtc со значением base=localtime (использование текущего времени хоста в качестве RTC гостевой машины), явным указанием даты запуска и др. вариантами — с помощью параметра Makefile, используемом по make qemu, чтобы можно было протестировать работу для разных значений RTC.

добавить утилиту пользовательского пространства data, конвертирующую значение времени RTC в строковую человекочитаемую дату (год, месяц, день, час, минута, секунда и доли секунды) и выводящую ее на печать.